### PR TITLE
Resolve flaky test for framework module

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/EnsembleTracker.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/EnsembleTracker.java
@@ -26,6 +26,9 @@ import java.io.ByteArrayInputStream;
 import java.io.Closeable;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -149,7 +152,12 @@ public class EnsembleTracker implements Closeable, CuratorWatcher {
     @VisibleForTesting
     public static String configToConnectionString(QuorumVerifier data) throws Exception {
         StringBuilder sb = new StringBuilder();
-        for (QuorumPeer.QuorumServer server : data.getAllMembers().values()) {
+
+        List<QuorumPeer.QuorumServer> servers =
+                new ArrayList<>(data.getAllMembers().values());
+        Collections.sort(servers, (a, b) -> a.toString().compareTo(b.toString()));
+
+        for (QuorumPeer.QuorumServer server : servers) {
             if (server.clientAddr == null) {
                 // Invalid client address configuration in zoo.cfg
                 continue;


### PR DESCRIPTION
# Problem

For these tests:

[INFO] org.apache.curator.framework.imps.TestReconfiguration#testAdd
[INFO] org.apache.curator.framework.imps.TestReconfiguration#testNewMembersWithEmptyList
[INFO] org.apache.curator.framework.imps.TestReconfiguration#testAddAsync
[INFO] org.apache.curator.framework.imps.TestReconfiguration#testAddAndRemove
[INFO] org.apache.curator.framework.imps.TestReconfiguration#testAddAndRemoveWithEmptyList
[INFO] org.apache.curator.framework.imps.TestReconfiguration#testBasicGetConfig
[INFO] org.apache.curator.framework.imps.TestReconfiguration#testRemoveWithChroot

They assume the order of the QuorumServer was same, but this is not necessary the case because QuorumMaj aggressively use Map to store it's data

```
    private Map<Long, QuorumPeer.QuorumServer> allMembers = new HashMap();
    private HashMap<Long, QuorumPeer.QuorumServer> votingMembers = new HashMap();
    private HashMap<Long, QuorumPeer.QuorumServer> observingMembers = new HashMap();
```
so because the order of the Map is indeterministic according to the [Oracle's official document](https://docs.oracle.com/javase/8/docs/api/java/util/HashMap.html#:~:text=This%20class%20makes%20no%20guarantees%20as%20to%20the%20order%20of%20the%20map), so this might trigger error message in different environments:

```
[ERROR] org.apache.curator.framework.imps.TestReconfiguration.testAdd  Time elapsed: 0.641 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <127.0.0.1:55254,127.0.0.1:55251,127.0.0.1:55248,0.0.0.0:55268> but was: <0.0.0.0:55268,127.0.0.1:55251,127.0.0.1:55248,127.0.0.1:55254>
        at org.apache.curator.framework.imps.TestReconfiguration.testAdd(TestReconfiguration.java:281)

```
# Solution

So the most precise way to deal with that would be change the configToConnectionString method to make sure when we serialize the configurations, we always get the same result, so that the tests will be safe in different environment (because the order of the map is undefined)

# Reproduce
This error can be reproduced with the [NondexTool](https://github.com/TestingResearchIllinois/NonDex) with the following command (you can try that without modifying the pom, but feel free to use the plugin to protect your project and make it safer 😊 ), and this kind problem is widely documented in [International Dataset of Flaky Tests (IDoFT)](https://github.com/TestingResearchIllinois/idoft)

```
mvn edu.illinois:nondex-maven-plugin:2.1.7-SNAPSHOT:nondex -pl /curator-framework -Dsurefire.useFile=false -Dtest=org.apache.curator.framework.imps.TestReconfiguration#[methodName]
```